### PR TITLE
Removing the call to addAnnotation that is causing problems

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "stereotype-client",
-	"version": "1.2.1",
+	"version": "1.2.2",
 	"description": "A simple client for Cimpress' Stereotype service.",
 	"main": "src/index.js",
 	"scripts": {

--- a/src/stereotype_client.js
+++ b/src/stereotype_client.js
@@ -80,7 +80,6 @@ class StereotypeClient {
             },
             (err) => {
               subsegment.addAnnotation('Response Code', err.status);
-              subsegment.addAnnotation('Error Message', 'Unable to get template: ' + err.message);
               subsegment.close(err);
               reject(new Error('Unable to get template: ' + err.message));
             }
@@ -109,7 +108,6 @@ class StereotypeClient {
         // Validate the body type, err via a Promise:
         if (!StereotypeClient._isSupportedBodyType(contentType)) {
           let err = new Error('Invalid content type: ' + contentType);
-          subsegment.addAnnotation('Error Message', 'Invalid content type: ' + contentType);
           subsegment.close(err);
           reject(err);
         }
@@ -129,7 +127,6 @@ class StereotypeClient {
             },
             (err) => {
               subsegment.addAnnotation('Response Code', err.status);
-              subsegment.addAnnotation('Error Message', 'Unable to create/update template: ' + err.message);
               subsegment.close(err);
               reject(new Error('Unable to create/update template: ' + err.message));
             }
@@ -217,7 +214,6 @@ class StereotypeClient {
             },
             (err) => {
               subsegment.addAnnotation('Response Code', err.status);
-              subsegment.addAnnotation('Error Message', 'Unable to get materialization: ' + err.message);
               subsegment.close(err);
               reject(new Error('Unable to get materialization: ' + err.message));
             }
@@ -295,7 +291,6 @@ class StereotypeClient {
             },
             (err) => {
               subsegment.addAnnotation('Response Code', err.status);
-              subsegment.addAnnotation('Error Message', 'Unable to get livecheck data: ' + err.message);
               subsegment.close(err);
               reject(new Error('Unable to get livecheck data: ' + err.message));
             }
@@ -326,7 +321,6 @@ class StereotypeClient {
             },
             (err) => {
               subsegment.addAnnotation('Response Code', err.status);
-              subsegment.addAnnotation('Error Message', ('Unable to get swagger: ' + err.message));
               subsegment.close(err);
               reject(new Error('Unable to get swagger: ' + err.message));
             }

--- a/src/stereotype_client.js
+++ b/src/stereotype_client.js
@@ -184,7 +184,6 @@ class StereotypeClient {
             },
             (err) => {
               subsegment.addAnnotation('Response Code', err.status);
-              subsegment.addAnnotation('Unable to materialize template: ' + err.message);
               subsegment.close(err);
               reject(new Error('Unable to materialize template: ' + err.message));
             }


### PR DESCRIPTION
This call is invalid and is causing errors.

    2017-09-27T18:10:18.615Z	1a42a98f-a3af-11e7-b3dc-29eaaad75982	(node:1) UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: 1): Error: Failed to add annotation key: Unable to materialize template: Bad Request value: undefined to subsegment Stereotype.materialize. Value must be of type string, number or boolean.

I propose to remove it, as I assume it was added accidentally.
